### PR TITLE
update ecommerce spec syntax to v2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# Appboy server-side integration.
+# Appboy server-side integration. [![CircleCI](https://circleci.com/gh/segment-integrations/integration-appboy/tree/master.svg?style=svg)](https://circleci.com/gh/segment-integrations/integration-appboy/tree/master)
 
 Appboy server-side integration for Segment.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ Appboy.prototype.identify = Appboy.prototype.track = Appboy.prototype.group = fu
 };
 
 /**
- * Completed Order. Must manually call the mapper for this one
+ * Order Completed. Must manually call the mapper for this one
  *
  * https://documentation.appboy.com/REST_APIs/User_Data
  *
@@ -47,8 +47,8 @@ Appboy.prototype.identify = Appboy.prototype.track = Appboy.prototype.group = fu
  * @param {Function} fn
  * @api public
  */
-Appboy.prototype.completedOrder = function(track, fn){
-  var payload = mapper.completedOrder(track, this.settings);
+Appboy.prototype.orderCompleted = function(track, fn){
+  var payload = mapper.orderCompleted(track, this.settings);
   return this
     .post()
     .send(payload)

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -40,14 +40,14 @@ exports.track = function(track, settings){
 };
 
 /**
-* Map 'Completed Order' events from the ECommerce API to track as purchases
+* Map 'Order Completed' events from the ECommerce API to track as purchases
 *
 * @param {Track} track
 * @param {Object} settings
 * @return {Object}
   * @api private
 */
-exports.completedOrder = function(track, settings){
+exports.orderCompleted = function(track, settings){
   var result = common(settings);
 
   var purchases = [];

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "test": "make test"
   },
   "dependencies": {
-    "segmentio-integration": "3.x"
+    "segmentio-integration": "4.x"
   },
   "devDependencies": {
     "istanbul": "0.x",
     "jscs": "1.x",
     "mocha": "2.x",
     "ms": "0.x",
-    "segmentio-integration-tester": "1.x",
+    "segmentio-integration-tester": "2.x",
     "should": "4.x",
     "unix-time": "1.x"
   }

--- a/test/fixtures/group-basic.json
+++ b/test/fixtures/group-basic.json
@@ -11,7 +11,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "attributes": [{
       "external_id": "group-user-id",
       "ab_segment_group_abcd123": true,

--- a/test/fixtures/group-update-existing-only.json
+++ b/test/fixtures/group-update-existing-only.json
@@ -11,7 +11,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "attributes": [{
       "external_id": "group-non-existing-user-id",
       "ab_segment_group_abcd123": true,

--- a/test/fixtures/identify-basic.json
+++ b/test/fixtures/identify-basic.json
@@ -20,7 +20,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "attributes": [{
       "external_id": "identify-user-id",
       "first_name": "Jane",

--- a/test/fixtures/identify-custom.json
+++ b/test/fixtures/identify-custom.json
@@ -15,7 +15,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "attributes": [{
       "external_id": "identify-custom-user-id",
       "custom_att_snake": "abc",

--- a/test/fixtures/identify-dob.json
+++ b/test/fixtures/identify-dob.json
@@ -12,7 +12,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "attributes": [{
       "external_id": "identify-dob-user-id",
       "dob": "1991-09-26",

--- a/test/fixtures/identify-gender.json
+++ b/test/fixtures/identify-gender.json
@@ -12,7 +12,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "attributes": [{
       "external_id": "identify-gender-user-id",
       "_update_existing_only": false

--- a/test/fixtures/identify-gender2.json
+++ b/test/fixtures/identify-gender2.json
@@ -12,7 +12,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "attributes": [{
       "external_id": "identify-gender-user-id",
       "gender": "Female",

--- a/test/fixtures/identify-gender3.json
+++ b/test/fixtures/identify-gender3.json
@@ -12,7 +12,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "attributes": [{
       "external_id": "identify-gender-user-id",
       "_update_existing_only": false

--- a/test/fixtures/identify-update-existing-only.json
+++ b/test/fixtures/identify-update-existing-only.json
@@ -15,7 +15,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "attributes": [{
       "external_id": "identify-non-existing-user-id",
       "first_name": "Jane",

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -14,7 +14,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "events": [
       {
         "external_id": "track-user-id",

--- a/test/fixtures/track-products-defaults.json
+++ b/test/fixtures/track-products-defaults.json
@@ -4,7 +4,7 @@
     "version": "2",
     "userId": "track-products-user-id",
     "timestamp": "2015-01-01T00:00:00.000Z",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "properties": {
       "products": [
         {

--- a/test/fixtures/track-products-defaults.json
+++ b/test/fixtures/track-products-defaults.json
@@ -28,7 +28,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "purchases": [
       {
         "external_id": "track-products-user-id",

--- a/test/fixtures/track-products-minor-error.json
+++ b/test/fixtures/track-products-minor-error.json
@@ -31,7 +31,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "purchases": [
       {
         "external_id": "track-products-minor-error-user-id",

--- a/test/fixtures/track-products-minor-error.json
+++ b/test/fixtures/track-products-minor-error.json
@@ -4,7 +4,7 @@
     "version": "2",
     "userId": "track-products-minor-error-user-id",
     "timestamp": "2015-01-01T00:00:00.000Z",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "properties": {
       "products": [
         {

--- a/test/fixtures/track-products.json
+++ b/test/fixtures/track-products.json
@@ -4,7 +4,7 @@
     "version": "2",
     "userId": "track-products-user-id",
     "timestamp": "2015-01-01T00:00:00.000Z",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "properties": {
       "products": [
         {

--- a/test/fixtures/track-products.json
+++ b/test/fixtures/track-products.json
@@ -31,7 +31,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "purchases": [
       {
         "external_id": "track-products-user-id",

--- a/test/fixtures/track-update-existing-only.json
+++ b/test/fixtures/track-update-existing-only.json
@@ -14,7 +14,7 @@
     }
   },
   "output": {
-    "app_group_id": "08dde1d6-362b-44ae-9264-f63fb8a101bf",
+    "app_group_id": "6bc2109a-770a-4ca3-8db7-775f1326f749",
     "events": [
       {
         "external_id": "track-non-existing-user-id",

--- a/test/index.js
+++ b/test/index.js
@@ -90,7 +90,7 @@ describe('Appboy', function(){
       });
     });
 
-    describe('completedOrder', function(){
+    describe('orderCompleted', function(){
       it('should map complete order tracks with products', function(){
         test.maps('track-products');
       });
@@ -137,7 +137,7 @@ describe('Appboy', function(){
     });
   });
 
-  describe('.completedOrder()', function(){
+  describe('.orderCompleted()', function(){
     it('should send track products', function(done){
       var json = test.fixture('track-products');
       var output = json.output;

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,7 @@ describe('Appboy', function(){
 
   beforeEach(function(){
     settings = {
-      appGroupId: '08dde1d6-362b-44ae-9264-f63fb8a101bf',
+      appGroupId: '6bc2109a-770a-4ca3-8db7-775f1326f749',
       trackPages: true,
       updateExistingOnly: false
     };


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.